### PR TITLE
fix: release strategy to refere to correct path

### DIFF
--- a/rh-push-to-registry-redhat-io/release-resources/release-strategy.yaml
+++ b/rh-push-to-registry-redhat-io/release-resources/release-strategy.yaml
@@ -27,7 +27,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/push-to-external-registry/push-to-external-registry.yaml
+        value: pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
     resolver: "git"
   policy: rh-push-to-registry-redhat-io-test-policy
   serviceAccount: release-service-account


### PR DESCRIPTION
This commit fixes the release strategy for `rh-push-to-registry-redhat-io` to refer to the correct pipeline path.