### PR TITLE
fix: rh-push-to-registry-redhat-io tests

### DIFF
--- a/rh-push-to-registry-redhat-io/release-resources/application.yaml
+++ b/rh-push-to-registry-redhat-io/release-resources/application.yaml
@@ -3,5 +3,5 @@ kind: Application
 metadata:
   name: rh-push-to-registry-redhat-iotest
 spec:
-  description: AppStudio
-  displayName: AppStudio
+  description: rh-push-to-registry-redhat-iotest
+  displayName: rh-push-to-registry-redhat-iotest

--- a/rh-push-to-registry-redhat-io/release-resources/buildpipelineselector.yaml
+++ b/rh-push-to-registry-redhat-io/release-resources/buildpipelineselector.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: BuildPipelineSelector
+metadata:
+  name: build-pipeline-selector
+  namespace: dev-release-team-tenant
+spec:
+  selectors:
+    - name: Docker build
+      pipelineRef:
+        bundle: >-
+          quay.io/redhat-appstudio-tekton-catalog/pipeline-docker-build:eb5492a82d57efe60d00d41ddb0798f6b34fab2e
+        name: docker-build
+      when:
+        dockerfile: true
+      pipelineParams:
+        - name: build-source-image
+          value: 'true'

--- a/rh-push-to-registry-redhat-io/release-resources/component.yaml
+++ b/rh-push-to-registry-redhat-io/release-resources/component.yaml
@@ -3,7 +3,6 @@ kind: Component
 metadata:
   name: rh-push-to-registry-redhat-iotest-component
   annotations:
-    pipelinesascode: '1'
     image.redhat.com/generate: 'true'
 spec:
   application: rh-push-to-registry-redhat-iotest

--- a/rh-push-to-registry-redhat-io/release-resources/ec-policy.yaml
+++ b/rh-push-to-registry-redhat-io/release-resources/ec-policy.yaml
@@ -8,12 +8,13 @@ spec:
     Includes rules for levels 1, 2 & 3 of SLSA v0.1.
   publicKey: "k8s://openshift-pipelines/public-key"
   sources:
-    - name: Default
+    - data:
+        - github.com/release-engineering/rhtap-ec-policy//data
+        - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
+      name: Default
       policy:
         - github.com/enterprise-contract/ec-policies//policy/lib
         - github.com/enterprise-contract/ec-policies//policy/release
-      data:
-        - github.com/release-engineering/rhtap-ec-policy//data
   configuration:
     include:
       - '@slsa1'

--- a/rh-push-to-registry-redhat-io/release-resources/release-plan-admission.yaml
+++ b/rh-push-to-registry-redhat-io/release-resources/release-plan-admission.yaml
@@ -19,14 +19,17 @@ spec:
         value: pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
     resolver: "git"
   policy: rh-push-to-registry-redhat-io-test-policy
-  serviceAccount: release-service-account
+  serviceAccount: rh-push-to-registry-redhat-io-sa
   data:
     pyxis:
       server: stage
       secret: pyxis
     images:
       addGitShaTag: true
+      tagPrefix: "rh-product-prefix"
     mapping:
       components:
         - name: rh-push-to-registry-redhat-iotest-component
-          repository: quay.io/hacbs-release-tests/rh-push-to-registry-redhat-iotest-component
+          repository: quay.io/redhat-pending/rhtap----rh-push-to-registry-redhat-iotest-component
+    sign:
+      configMapName: hacbs-signing-pipeline-config-redhatrelease2

--- a/rh-push-to-registry-redhat-io/test.sh
+++ b/rh-push-to-registry-redhat-io/test.sh
@@ -6,6 +6,7 @@ APPLICATION_NAME="rh-push-to-registry-redhat-iotest"
 COMPONENT_NAME="rh-push-to-registry-redhat-iotest-component"
 RELEASE_PLAN_NAME="rh-push-to-registry-redhat-io-test-rp"
 RELEASE_PLAN_ADMISSION_NAME="rh-push-to-registry-redhat-io-test-rpa"
+BUILD_PIPELINE_SELECTOR_NAME="rh-push-to-registry-redhat-io-build-pipeline-selector"
 TIMEOUT_SECONDS=600
 
 DEV_WORKSPACE="dev-release-team"
@@ -39,6 +40,9 @@ print_help(){
 
 function setup() {
 
+    echo "Creating BuildPipelineSelector"
+    kubectl apply -f release-resources/buildpipelineselector.yaml "${DEV_KUBECONFIG_ARG}"
+
     echo "Creating Application"
     kubectl apply -f release-resources/application.yaml "${DEV_KUBECONFIG_ARG}"
 
@@ -62,6 +66,7 @@ function teardown() {
     kubectl delete pr -l "appstudio.openshift.io/application=$APPLICATION_NAME,pipelines.appstudio.openshift.io/type=release" "${MANAGED_KUBECONFIG_ARG}"
     kubectl delete release "${DEV_KUBECONFIG_ARG}" -o=jsonpath="{.items[?(@.spec.releasePlan==\"$RELEASE_PLAN_NAME\")].metadata.name}"
     kubectl delete releaseplanadmission "$RELEASE_PLAN_ADMISSION_NAME" "${MANAGED_KUBECONFIG_ARG}"
+    kubectl delete buildpipelineselector "${BUILD_PIPELINE_SELECTOR_NAME}" "${DEV_KUBECONFIG_ARG}"
 
     if kubectl get application "$APPLICATION_NAME"  "${DEV_KUBECONFIG_ARG}" &> /dev/null; then
         echo "Application $APPLICATION_NAME exists. Deleting..."


### PR DESCRIPTION
- add support for BuildPipelineSelector to select the correct pipeline with te build-source-image parameter